### PR TITLE
no-use-before-define

### DIFF
--- a/packages/@addepar/eslint-config/index.js
+++ b/packages/@addepar/eslint-config/index.js
@@ -66,6 +66,8 @@ module.exports = {
       'ember'
     ],
 
+    'no-use-before-define': ['error', { 'functions': false }],
+
     // Prettier plugin
     'prettier/prettier': 'error',
 


### PR DESCRIPTION
https://eslint.org/docs/rules/no-use-before-define

false for functions because they, unlike variables and classes, are hoisted.

reviewers: @Addepar/web-core 