### PR TITLE
[CHORE] Ensure addon-test-support/ is eslint'd

### DIFF
--- a/packages/@addepar/eslint-config/ember.js
+++ b/packages/@addepar/eslint-config/ember.js
@@ -27,6 +27,7 @@ module.exports = {
       excludedFiles: [
         'app/**',
         'addon/**',
+        'addon-test-support/**',
         'tests/dummy/app/**',
       ],
       parserOptions: {


### PR DESCRIPTION
Ensure that the ember eslint config doesn't skip files in `addon-test-support/`