### PR TITLE
Merge in updates to sass-lint-config from upstream

### DIFF
--- a/packages/@addepar/sass-lint-config/README.md
+++ b/packages/@addepar/sass-lint-config/README.md
@@ -1,23 +1,43 @@
 # @addepar/sass-lint-config
 
-This is the Sass Lint config used for Sass projects at Addepar.
+[List of available sass-lint rules](https://github.com/sasstools/sass-lint/tree/master/docs/rules)
 
-## Using the plugin
+## Setup
+Add this dependency to devDependencies in your project
 
-### Installation
+`yarn add --dev @addepar/sass-lint-config`
 
-Install the plugin as a dev dependency in your project.
-
-```bash
-yarn add --dev @addepar/sass-lint-config
+Then add a `.sass-lint.yml` file to the root of your project
+```
+options:
+  config-file: ./node_modules/@addepar/sass-lint-config/config.yml
+files:
+  include: '[your-project-css-path]/**/*.s+(a|c)ss'
 ```
 
-### Configuration
+## Run sass-lint in your project
+`./node_modules/sass-lint/bin/sass-lint.js -vq`
 
-Link to the sass-lint config in `.sass-lint.yml`
+## Disabling rules
 
-```yml
-# .sass-lint.yml
-options:
-  config-file: node_modules/@addepar/sass-lint-config/config.yml
+### Disable for whole file
+
+```
+// sass-lint:disable no-ids
+
+#root {
+  ...
+}
+```
+
+### Disable rule for single line
+
+`color: pink; // sass-lint:disable-line no-color-literals`
+
+### Disable rule for selector block
+```
+p {
+  // sass-lint:disable-block no-color-literals
+  color: pink;
+}
 ```

--- a/packages/@addepar/sass-lint-config/config.yml
+++ b/packages/@addepar/sass-lint-config/config.yml
@@ -23,7 +23,6 @@ rules:
   single-line-per-selector: 2
 
   # Disallows
-  no-color-keywords: 2
   no-debug: 2
   no-duplicate-properties:
     - 2

--- a/packages/@addepar/sass-lint-config/package.json
+++ b/packages/@addepar/sass-lint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@addepar/sass-lint-config",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "Addepar sass-lint configuration",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
This repo was forked from https://github.com/Addepar/sass-lint-config and slightly diverged, but the original repo was never properly retired. Over time, both were being used for publishing new packages.

This merges the now embarrassingly small change to `config.yml` into this repo. The original upstream repo will be retired.