### PR TITLE
Add override to specify `singleQuote: false` for *.hbs files

### DIFF
--- a/packages/@addepar/prettier-config/index.js
+++ b/packages/@addepar/prettier-config/index.js
@@ -4,4 +4,12 @@ module.exports = {
   singleQuote: true,
   trailingComma: 'es5',
   printWidth: 100,
+  overrides: [
+    {
+      files: '*.hbs',
+      options: {
+        singleQuote: false
+      }
+    }
+  ]
 };


### PR DESCRIPTION
Prettier recently added support for handelbars files via a "glimmer"
parser [1].

Editor formatting extensions like the VS Code handlebars-formatter [2]
that respect the [prettier configuration file](https://prettier.io/docs/en/configuration.html) for *.hbs files will start
formatting them using single-quoted attribute strings.

This adds an override to ensure that the formatter will still use
double quotes around attributes in *.hbs files.

[1] https://prettier.io/blog/2019/11/09/1.19.0.html
[2] https://github.com/mfeckie/handlebars-formatter