### PR TITLE
upgrade eslint-plugin-import to ^2.20.0

### DIFF
--- a/packages/@addepar/eslint-config/package.json
+++ b/packages/@addepar/eslint-config/package.json
@@ -8,9 +8,9 @@
   },
   "dependencies": {
     "eslint-config-prettier": "^2.9.0",
-    "eslint-plugin-ember": "^5.0.1",
+    "eslint-plugin-ember": "^7.7.2",
     "eslint-plugin-ember-best-practices": "^1.1.1",
-    "eslint-plugin-import": "^2.3.0",
+    "eslint-plugin-import": "^2.20.0",
     "eslint-plugin-node": "^6.0.1",
     "eslint-plugin-prefer-let": "^1.0.1",
     "eslint-plugin-prettier": "^2.6.0"


### PR DESCRIPTION
eslint v6 support was only added in v2.18. Upgrade this dep
so that consumers (typically via `@addepar/ember-toolbox`) can use
eslint v6

Changelog: https://github.com/benmosher/eslint-plugin-import/blob/master/CHANGELOG.md