### PR TITLE
Drop ember-best-practices plugin

### DIFF
--- a/packages/@addepar/eslint-config/README.md
+++ b/packages/@addepar/eslint-config/README.md
@@ -2,7 +2,7 @@
 
 This ESLint plugin supports both Javascript and Ember.js linting.
 
-Ember.js specific rules include both [ember-best-practices](https://github.com/ember-best-practices/eslint-plugin-ember-best-practices) and [eslint-plugin-ember](https://github.com/ember-cli/eslint-plugin-ember).
+Ember.js specific rules from [eslint-plugin-ember](https://github.com/ember-cli/eslint-plugin-ember).
 
 ## Using the plugin with Ember CLI
 
@@ -21,9 +21,7 @@ To include just Javascript rules:
 ```js
 // .eslintrc.js
 module.exports = {
-  extends: [
-    '@addepar'
-  ],
+  extends: ["@addepar"],
   rules: {
     // custom rules
     // rules overrides
@@ -36,9 +34,7 @@ To include just Ember.js rules:
 ```js
 // .eslintrc.js
 module.exports = {
-  extends: [
-    '@addepar/eslint-config/ember'
-  ],
+  extends: ["@addepar/eslint-config/ember"],
   rules: {
     // custom rules
     // rules overrides

--- a/packages/@addepar/eslint-config/ember.js
+++ b/packages/@addepar/eslint-config/ember.js
@@ -7,41 +7,42 @@ module.exports = {
   root: true,
   parserOptions: {
     ecmaVersion: 2017,
-    sourceType: 'module',
+    sourceType: "module"
   },
-  extends: [
-    'plugin:ember/recommended',
-    'plugin:ember-best-practices/recommended',
-  ],
-  rules: { },
+  extends: ["plugin:ember/recommended"],
+  rules: {},
   overrides: [
     // node files
     {
       files: [
-        'index.js',
-        'testem.js',
-        'ember-cli-build.js',
-        'config/**/*.js',
-        'tests/dummy/config/**/*.js',
+        "index.js",
+        "testem.js",
+        "ember-cli-build.js",
+        "config/**/*.js",
+        "tests/dummy/config/**/*.js"
       ],
       excludedFiles: [
-        'app/**',
-        'addon/**',
-        'addon-test-support/**',
-        'tests/dummy/app/**',
+        "app/**",
+        "addon/**",
+        "addon-test-support/**",
+        "tests/dummy/app/**"
       ],
       parserOptions: {
-        sourceType: 'script',
-        ecmaVersion: 2015,
+        sourceType: "script",
+        ecmaVersion: 2015
       },
       env: {
         browser: false,
-        node: true,
+        node: true
       },
-      plugins: ['node'],
-      rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
-        // add your custom rules and overrides for node files here
-      }),
-    },
-  ],
+      plugins: ["node"],
+      rules: Object.assign(
+        {},
+        require("eslint-plugin-node").configs.recommended.rules,
+        {
+          // add your custom rules and overrides for node files here
+        }
+      )
+    }
+  ]
 };

--- a/packages/@addepar/eslint-config/package.json
+++ b/packages/@addepar/eslint-config/package.json
@@ -9,7 +9,6 @@
   "dependencies": {
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-ember": "^5.0.1",
-    "eslint-plugin-ember-best-practices": "^1.1.1",
     "eslint-plugin-import": "^2.3.0",
     "eslint-plugin-node": "^6.0.1",
     "eslint-plugin-prefer-let": "^1.0.1",


### PR DESCRIPTION
The eslint-plugin-ember-best-practices's recommended rules [1] are all covered by
the eslint-plugin-ember's recommended rules [2].

Additionally, eslint-plugin-ember-best-practices, although not officially deprecated,
seems to be fairly stagnant. It has only had one patch release in the past 3 years.

[1] https://github.com/ember-best-practices/eslint-plugin-ember-best-practices/blob/79d5f485b7004953b6510f2ea82759a8e1c43d03/config/recommended.js#L12-L23
[2] https://github.com/ember-cli/eslint-plugin-ember

