### PR TITLE
Upgrade to eslint-plugin-ember ^7.7.2 (from ^5.0.1)

### DIFF
--- a/packages/@addepar/eslint-config/package.json
+++ b/packages/@addepar/eslint-config/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "eslint-config-prettier": "^2.9.0",
-    "eslint-plugin-ember": "^5.0.1",
+    "eslint-plugin-ember": "^7.7.2",
     "eslint-plugin-ember-best-practices": "^1.1.1",
     "eslint-plugin-import": "^2.3.0",
     "eslint-plugin-node": "^6.0.1",


### PR DESCRIPTION
Changelog: https://github.com/ember-cli/eslint-plugin-ember/blob/master/CHANGELOG.md

Breaking changes:
 - drop eslint v4, node 6 support (v7)
 - drop eslint v3, node 4 support (v6)
 - changes to "recommended" rules in v6 and v7

Note: After landing this, we should release in a new major version