### PR TITLE
Upgrade to eslint-plugin-node ^11 from ^6

### DIFF
--- a/packages/@addepar/eslint-config/package.json
+++ b/packages/@addepar/eslint-config/package.json
@@ -11,7 +11,7 @@
     "eslint-plugin-ember": "^5.0.1",
     "eslint-plugin-ember-best-practices": "^1.1.1",
     "eslint-plugin-import": "^2.3.0",
-    "eslint-plugin-node": "^6.0.1",
+    "eslint-plugin-node": "^11.0.0",
     "eslint-plugin-prefer-let": "^1.0.1",
     "eslint-plugin-prettier": "^2.6.0"
   },


### PR DESCRIPTION
Changelog: https://github.com/mysticatea/eslint-plugin-node/releases

Breaking changes:
 - drop node 6, eslint 4 (v9)
 - drop node 4, eslint 3 (v7)
 - miscellaneous updates to recommended and other rules