### PR TITLE
Upgrade eslint-config-prettier, eslint-plugin-prettier

### DIFF
--- a/packages/@addepar/eslint-config/package.json
+++ b/packages/@addepar/eslint-config/package.json
@@ -13,7 +13,7 @@
     "eslint-plugin-import": "^2.3.0",
     "eslint-plugin-node": "^6.0.1",
     "eslint-plugin-prefer-let": "^1.0.1",
-    "eslint-plugin-prettier": "^2.6.0"
+    "eslint-plugin-prettier": "^3.1.2"
   },
   "author": "",
   "repository": {

--- a/packages/@addepar/eslint-config/package.json
+++ b/packages/@addepar/eslint-config/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "eslint-config-prettier": "^2.9.0",
+    "eslint-config-prettier": "^6.10.0",
     "eslint-plugin-ember": "^5.0.1",
     "eslint-plugin-ember-best-practices": "^1.1.1",
     "eslint-plugin-import": "^2.3.0",


### PR DESCRIPTION
The prettier *plugin* adds a rule 'prettier/prettier' that makes it an error if any file is not formatted the way prettier would do it.

The prettier *config* modifies the ruleset to *turn off* any eslint formatting-focused rules so that they don't conflict with the 'prettier/prettier' rule.

### Upgrade eslint-plugin-prettier from ^2 to ^3:

Changelog: https://github.com/prettier/eslint-plugin-prettier/blob/master/CHANGELOG.md

Breaking changes:
 - drop eslint v3, v4
 - minimum required prettier is >= 1.13
 - drop node v4, v7, v9

### Upgrade eslint-config-prettier from ^2 to ^6:
Changelog:
https://github.com/prettier/eslint-config-prettier/blob/master/CHANGELOG.md

There are a handful of tweaks and exceptions to rules that are added in the 
changelog. Despite the large-ish version jump here there are not that many
changes that look to me to be particularly significant.