### PR TITLE
Lint monorepo addon browser files as browser files

### DIFF
--- a/packages/@addepar/eslint-config/ember.js
+++ b/packages/@addepar/eslint-config/ember.js
@@ -23,9 +23,17 @@ module.exports = {
       ],
       excludedFiles: [
         "app/**",
+        "packages/*/app/**",
+        "packages/@addepar/*/app/**",
         "addon/**",
+        "packages/*/addon/**",
+        "packages/@addepar/*/addon/**",
         "addon-test-support/**",
-        "tests/dummy/app/**"
+        "packages/*/addon-test-support/**",
+        "packages/@addepar/*/addon-test-support/**",
+        "tests/dummy/app/**",
+        "packages/*/tests/dummy/app/**",
+        "packages/@addepar/*/tests/dummy/app/**"
       ],
       parserOptions: {
         sourceType: "script",


### PR DESCRIPTION
Files in the Iverson monorepo may be in the `packages/` folder, either with a `@addepar/` namespace for the package name or without. Ensure files in those libraries are properly linted as browser JS instead of Node.